### PR TITLE
Update Test_TC_I_2_3.yaml

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_I_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_I_2_3.yaml
@@ -16,6 +16,7 @@ name: 57.2.3. [TC-I-2.3] Secondary functionality with server as DUT
 
 PICS:
     - I.S
+    - I.S.C40.Rsp
 
 config:
     nodeId: 0x12344321


### PR DESCRIPTION
- This test case is about effects on the DUT, there is not reason the run a single step from this test case if the item "I.S.C40.Rsp" is not declared as supported.

#### Problem
What is being fixed?  Examples:
* remove test case from applicable test cases when I.S.C40.Rsp is set to false

#### Change overview
section was edited
PICS:
    - I.S
    - I.S.C40.Rsp

#### Testing
How was this tested? (at least one bullet point required)
* Just load the xml pics with the I.S.C40.Rsp set to false and you will see that test case is added to the applicable test cases.